### PR TITLE
Add JEmalloc configuration output

### DIFF
--- a/gathermetadata/__main__.py
+++ b/gathermetadata/__main__.py
@@ -107,7 +107,8 @@ _recordables = {
     "scontrol": "scontrol show jobid ${SLURM_JOBID} -d",
     "mpivars": "mpivars",
     "pldd-nest": "python -c \"import nest, subprocess as s, os; s.check_call(['/usr/bin/pldd', str(os.getpid())])\"",
-    "malloc_conf_json": "MALLOC_CONF='stats_print:true' /bin/true", # see https://jemalloc.net/jemalloc.3.html#opt.stats_print
+    # see https://jemalloc.net/jemalloc.3.html#opt.stats_print
+    "malloc_conf_json": "MALLOC_CONF='stats_print:true' /bin/true",
 }
 
 

--- a/gathermetadata/__main__.py
+++ b/gathermetadata/__main__.py
@@ -107,6 +107,7 @@ _recordables = {
     "scontrol": "scontrol show jobid ${SLURM_JOBID} -d",
     "mpivars": "mpivars",
     "pldd-nest": "python -c \"import nest, subprocess as s, os; s.check_call(['/usr/bin/pldd', str(os.getpid())])\"",
+    "malloc_conf_json": "MALLOC_CONF='stats_print:true' /bin/true", # see https://jemalloc.net/jemalloc.3.html#opt.stats_print
 }
 
 

--- a/gathermetadata/__main__.py
+++ b/gathermetadata/__main__.py
@@ -108,7 +108,7 @@ _recordables = {
     "mpivars": "mpivars",
     "pldd-nest": "python -c \"import nest, subprocess as s, os; s.check_call(['/usr/bin/pldd', str(os.getpid())])\"",
     # see https://jemalloc.net/jemalloc.3.html#opt.stats_print
-    "malloc_conf_json": "MALLOC_CONF='stats_print:true,stats_print_opts:J' /bin/true",
+    "malloc_conf_json": 'MALLOC_CONF="${MALLOC_CONF:+$MALLOC_CONF,}stats_print:true,stats_print_opts:J" /bin/true',
 }
 
 

--- a/gathermetadata/__main__.py
+++ b/gathermetadata/__main__.py
@@ -108,7 +108,7 @@ _recordables = {
     "mpivars": "mpivars",
     "pldd-nest": "python -c \"import nest, subprocess as s, os; s.check_call(['/usr/bin/pldd', str(os.getpid())])\"",
     # see https://jemalloc.net/jemalloc.3.html#opt.stats_print
-    "malloc_conf_json": "MALLOC_CONF='stats_print:true' /bin/true",
+    "malloc_conf_json": "MALLOC_CONF='stats_print:true,stats_print_opts:J' /bin/true",
 }
 
 


### PR DESCRIPTION
This command starts a dummy program (`/bin/true`) with JEmalloc configured to print it's configuration upon exit. The statistics will all be for the dummy, so almost empty, but static configuration data is useful to understand also calls to other programs.